### PR TITLE
Support multi line imports :tada:

### DIFF
--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -82,6 +82,7 @@ func getImports(fileName string) []types.ImportInfo {
 
 	lineNum := 1
 	scanner := bufio.NewScanner(file)
+	scanner.Split(utils.GetSplitterFunc(';'))
 
 	for scanner.Scan() {
 		line := scanner.Text()

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -13,8 +13,7 @@ import (
 	"../utils"
 )
 
-var pat = regexp.MustCompile(`\bimport (?P<name>(?:.*\n*)+) from (?P<module>(?:.*\n*)+)`)
-var commentPat = regexp.MustCompile(`// *import`)
+var pat = regexp.MustCompile(`(?sm)^import (?P<name>.+)\s*from\s+(?P<module>\S+)`)
 
 // ParseImport will mutate the passed map with all the dependent imports and their info
 func ParseImport(files []string, importMap map[string]interface{}) {
@@ -87,9 +86,8 @@ func getImports(fileName string) []types.ImportInfo {
 	for scanner.Scan() {
 		line := scanner.Text()
 		submatches := pat.FindStringSubmatch(line)
-		commentMatch := commentPat.FindString(line)
 
-		if len(submatches) != 0 && commentMatch == "" {
+		if len(submatches) != 0 {
 			name := submatches[1]
 			module := submatches[2]
 			importedFilePath := strings.Trim(module, "'\";")

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -13,7 +13,8 @@ import (
 	"../utils"
 )
 
-var pat = regexp.MustCompile(`^import (?P<name>.+) from (?P<module>.+)`)
+var pat = regexp.MustCompile(`\bimport (?P<name>(?:.*\n*)+) from (?P<module>(?:.*\n*)+)`)
+var commentPat = regexp.MustCompile(`// *import`)
 
 // ParseImport will mutate the passed map with all the dependent imports and their info
 func ParseImport(files []string, importMap map[string]interface{}) {

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -87,8 +87,9 @@ func getImports(fileName string) []types.ImportInfo {
 	for scanner.Scan() {
 		line := scanner.Text()
 		submatches := pat.FindStringSubmatch(line)
+		commentMatch := commentPat.FindString(line)
 
-		if len(submatches) != 0 {
+		if len(submatches) != 0 && commentMatch == "" {
 			name := submatches[1]
 			module := submatches[2]
 			importedFilePath := strings.Trim(module, "'\";")

--- a/utils/scanner.go
+++ b/utils/scanner.go
@@ -1,0 +1,23 @@
+package utils
+
+import "bufio"
+
+func GetSplitterFunc(char byte) func([]byte, bool) (int, []byte, error) {
+	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+
+		for i := 0; i < len(data); i++ {
+			if data[i] == char {
+				return i + 1, data[:i], nil
+			}
+		}
+
+		if !atEOF {
+			return 0, nil, nil
+		}
+
+		// There is one final token to be delivered, which may be the empty string.
+		// Returning bufio.ErrFinalToken here tells Scan there are no more tokens after this
+		// but does not trigger an error to be returned from Scan itself.
+		return 0, data, bufio.ErrFinalToken
+	}
+}

--- a/utils/scanner.go
+++ b/utils/scanner.go
@@ -2,6 +2,11 @@ package utils
 
 import "bufio"
 
+// GetSplitterFunc returns a splitter function based for the provided character.
+// The returned splitter function can then be passed to scanner.Split function.
+//
+// The splitter function returned is based on following example from official Go documentation:
+// https://golang.org/pkg/bufio/#example_Scanner_emptyFinalToken
 func GetSplitterFunc(char byte) func([]byte, bool) (int, []byte, error) {
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 


### PR DESCRIPTION
## Changes

* Add utils to get splitter funcion for bufio scanner
* Update import pattern regex and add regex to filter comments
* Use splitter function to split on semicolons
* Filter out matches if they match comments pattern
* Improve regular expression and remove need for comment pattern check :tada:
* Add doc comments for `GetSplitterFunc`