### PR TITLE
Refactor `getImports` core function

### DIFF
--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -108,15 +108,7 @@ func getImports(fileName string) []types.ImportInfo {
 					importedFilePath = path.Join(path.Dir(fileName), importedFilePath)
 				}
 
-				i := 0
-				ext := ""
-				done := false
-
-				for !done {
-					done, ext, err = getExt(importedFilePath, i)
-					utils.CheckError(err)
-					i++
-				}
+				ext := getExt(importedFilePath)
 
 				fi, err := os.Stat(importedFilePath + ext)
 
@@ -179,16 +171,14 @@ func updateMap(paths []types.ImportInfo, importMap map[string]interface{}) ([]st
 	return localPaths, importMap
 }
 
-func getExt(fpath string, count int) (bool, string, error) {
-	if count >= len(Extensions) {
-		return false, "", errors.New("Oops no more extensions available: " + fpath)
+func getExt(fpath string) string {
+	for i := range Extensions {
+		_, err := os.Stat(fpath + Extensions[i])
+
+		if err == nil {
+			return Extensions[i]
+		}
 	}
 
-	_, err := os.Stat(fpath + Extensions[count])
-
-	if err != nil {
-		return false, Extensions[count], nil
-	}
-
-	return true, Extensions[count], nil
+	panic(errors.New("Oops no more extensions available: " + fpath))
 }

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -88,7 +88,8 @@ func getImports(fileName string) []types.ImportInfo {
 		if len(submatches) != 0 {
 			name := submatches["name"]
 			module := submatches["module"]
-			importedFilePath := strings.Join(
+
+			modulePath := strings.Join(
 				strings.Split(
 					strings.Trim(module, "'\";"),
 					PathDelimiter,
@@ -98,30 +99,21 @@ func getImports(fileName string) []types.ImportInfo {
 
 			isDir := false
 
-			isRel := utils.IsRel(importedFilePath)
-			pathIsFromBaseDir, baseDir := utils.StartsWithAnyOf(LocalDirs, importedFilePath, "/")
+			isRel := utils.IsRel(modulePath)
+			pathIsFromBaseDir, baseDir := utils.StartsWithAnyOf(LocalDirs, modulePath, "/")
 
 			if isRel || pathIsFromBaseDir {
 				if pathIsFromBaseDir {
-					importedFilePath = path.Join(BaseDirAbsPathMap[baseDir], importedFilePath)
+					modulePath = path.Join(BaseDirAbsPathMap[baseDir], modulePath)
 				} else {
-					importedFilePath = path.Join(path.Dir(fileName), importedFilePath)
+					modulePath = path.Join(path.Dir(fileName), modulePath)
 				}
 
-				ext := getExt(importedFilePath)
-
-				fi, err := os.Stat(importedFilePath + ext)
-
-				if err == nil && fi.IsDir() {
-					isDir = true
-					importedFilePath += "/"
-				} else {
-					importedFilePath += ext
-				}
+				modulePath, isDir = getFilePath(modulePath)
 			}
 
 			imports = append(imports, types.ImportInfo{
-				Path:  importedFilePath,
+				Path:  modulePath,
 				IsDir: isDir,
 				Importers: []types.ImportedIn{
 					{

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -171,12 +171,14 @@ func updateMap(paths []types.ImportInfo, importMap map[string]interface{}) ([]st
 	return localPaths, importMap
 }
 
-func getExt(fpath string) string {
+func getFilePath(fpath string) (string, bool) {
 	for i := range Extensions {
-		_, err := os.Stat(fpath + Extensions[i])
+		path := fpath + Extensions[i]
+
+		fi, err := os.Stat(path)
 
 		if err == nil {
-			return Extensions[i]
+			return path, fi.IsDir()
 		}
 	}
 

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -155,7 +155,7 @@ func updateMap(paths []types.ImportInfo, importMap map[string]interface{}) ([]st
 			Info: types.ImportInfo{
 				Path:      p.Path,
 				IsDir:     p.IsDir,
-				Importers: append(p.Importers, importedIn...),
+				Importers: append(importedIn, p.Importers...),
 			},
 		}
 	}

--- a/core/ParseImports.go
+++ b/core/ParseImports.go
@@ -163,6 +163,9 @@ func updateMap(paths []types.ImportInfo, importMap map[string]interface{}) ([]st
 	return localPaths, importMap
 }
 
+// Iterates over Extensions (languageSpecific) and
+// returns filePath and isDir boolean if a file exists
+// throws error if no file is found.
 func getFilePath(fpath string) (string, bool) {
 	for i := range Extensions {
 		path := fpath + Extensions[i]

--- a/core/maps.go
+++ b/core/maps.go
@@ -11,12 +11,12 @@ import (
 // ImportPatternMap map constant
 var ImportPatternMap = map[string][]string{
 	"ts": {
-		`^import (?P<name>.+)\s*from\s+(?P<module>\S+)`,
+		`^import (?P<name>[^;]+)\s*from\s+['"](?P<module>\S+)['"]`,
 		`^\s*(?:const|let|var)\s+(?P<name>\S+)\s*=\s*require\((?P<module>\S+)\)`,
 		`^\s*(?:const|let|var)\s+(?P<name>\S+)\s*=\s*\S+\(\(\)\s*=>\s*import\((?P<module>\S+)\)\)`,
 	},
 	"py": {
-		`(?sm)(?:^import\s+(?P<module>\S+)`,
+		`^import\s+(?P<module>\S+)`,
 		`^from (?P<module>\S+)\s*import\s+(?P<name>\S+)`,
 	},
 }

--- a/core/maps.go
+++ b/core/maps.go
@@ -10,12 +10,12 @@ import (
 
 // ImportPatternMap map constant
 var ImportPatternMap = map[string][]string{
-	"ts": []string{
+	"ts": {
 		`^import (?P<name>.+)\s*from\s+(?P<module>\S+)`,
 		`^\s*(?:const|let|var)\s+(?P<name>\S+)\s*=\s*require\((?P<module>\S+)\)`,
 		`^\s*(?:const|let|var)\s+(?P<name>\S+)\s*=\s*\S+\(\(\)\s*=>\s*import\((?P<module>\S+)\)\)`,
 	},
-	"py": []string{
+	"py": {
 		`(?sm)(?:^import\s+(?P<module>\S+)`,
 		`^from (?P<module>\S+)\s*import\s+(?P<name>\S+)`,
 	},
@@ -23,8 +23,8 @@ var ImportPatternMap = map[string][]string{
 
 // ExtensionMap map constant
 var ExtensionMap = map[string][]string{
-	"ts": []string{"/index.ts", "/index.tsx", "/index.js", "", ".tsx", ".ts", ".js", ".json"},
-	"py": []string{".py", "main.py", ""},
+	"ts": {"/index.ts", "/index.tsx", "/index.js", "", ".tsx", ".ts", ".js", ".json"},
+	"py": {".py", "main.py", ""},
 }
 
 // SplitCharMap map constant

--- a/tests/utils/maps_test.go
+++ b/tests/utils/maps_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"reflect"
+	"regexp"
+	"testing"
+
+	"../../utils"
+)
+
+/**
+  Should match given string and return a map of submatches.
+**/
+func TestFindAllNamedMatches(t *testing.T) {
+	str := `
+    This is a string.
+    This is another line in the same string.
+    This is last line in string.
+  `
+	re := regexp.MustCompile(`(?P<this>This) is (?P<a>a\S*) [^\n]*`)
+
+	expected := []map[string]string{
+		{
+			"":     "This is a string.",
+			"a":    "a",
+			"this": "This",
+		},
+		{
+			"":     "This is another line in the same string.",
+			"a":    "another",
+			"this": "This",
+		},
+	}
+
+	actual := utils.FindAllNamedMatches(re, str)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("Filtered result did not match expected output\ngot:\n  \"%s\"\nexpected:\n  \"%s\"", actual, expected)
+	}
+}

--- a/types/ImportedIn.go
+++ b/types/ImportedIn.go
@@ -2,7 +2,6 @@ package types
 
 // ImportedIn type
 type ImportedIn struct {
-	Line   int
 	Name   string
 	Module string
 	Path   string

--- a/utils/maps.go
+++ b/utils/maps.go
@@ -72,3 +72,27 @@ func FindNamedMatches(regex *regexp.Regexp, str string) map[string]string {
 
 	return results
 }
+
+// FindAllNamedMatches creates a slice of maps of submatches and returns the slice.
+func FindAllNamedMatches(regex *regexp.Regexp, str string) []map[string]string {
+	matches := regex.FindAllStringSubmatch(str, -1)
+	subexpNames := regex.SubexpNames()
+
+	var result []map[string]string
+
+	for _, match := range matches {
+		matchMap := map[string]string{}
+
+		for i, name := range match {
+			val, exists := matchMap[subexpNames[i]]
+
+			if !exists || val == "" {
+				matchMap[subexpNames[i]] = name
+			}
+		}
+
+		result = append(result, matchMap)
+	}
+
+	return result
+}


### PR DESCRIPTION
## Changes

* Refactor `getExt` to include interation logic
* Modify and rename `getExt` -> `getFilePath`
* Use the new `getFilePath` func instead of `getExt`
* Remove redundant type info from maps
* Store importers info in order of file resolution
* Add `getFilePath` doc comment
* Fix import regexes
* Create util `FindAllNamedMatches` to get a slice of maps of submatches
* Remove Line from `ImportedIn` type
* Refactor `getImports`
* Add tests for maps util

## Details

Some major changes in core logic:

1. Read entire file instead of splitting file by SplitChar.
2. Use `FindAllNamedMatches` throughout the file instead of finding single match per chunk of file.
3. Removed Line field from `ImportedIn` part of import info.
4. Do not parse directories.